### PR TITLE
Name lookup v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@
 cmake-build-debug/**/*
 cmake-build-debug-coverage/**/*
 cmake-build-release/**/*
-examples/test.eis
+examples/test.wis
 build/**/*
 venv/
 .vscode/

--- a/examples/make-test.py
+++ b/examples/make-test.py
@@ -5,7 +5,7 @@ def tab(file, n):
 if __name__ == '__main__':
     a = lambda a: ord(a)
     b = lambda b: chr(b)
-    with open('test.eis', 'wt') as f:
+    with open('test.wis', 'wt') as f:
         for i in range(a('A'), a('Z') + 1):
             for j in range(a('A'), a('Z') + 1):
                 for k in range(a('A'), a('Z') + 1):

--- a/src/Module.hpp
+++ b/src/Module.hpp
@@ -11,13 +11,14 @@
 
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 struct Module {
     std::string name{};
     std::string module_directory{};
-    std::vector<ClassStmt *> classes{};
-    std::vector<FunctionStmt *> functions{};
+    std::unordered_map<std::string_view, ClassStmt*> classes{};
+    std::unordered_map<std::string_view, FunctionStmt*> functions{};
     std::vector<stmt_node_t> statements{};
     std::vector<std::size_t> imported{}; // Indexes into Parser::parsed_modules (better than pointers)
 

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -507,10 +507,8 @@ stmt_node_t Parser::declaration() {
 stmt_node_t Parser::class_declaration() {
     consume("Expected class name after 'class' keyword", TokenType::IDENTIFIER);
 
-    for (auto *class_ : current_module.classes) {
-        if (class_->name.lexeme == previous().lexeme) {
-            throw_parse_error("Class already defined");
-        }
+    if (current_module.classes.find(previous().lexeme) != current_module.classes.end()) {
+        throw_parse_error("Class already defined");
     }
 
     Token name = previous();
@@ -580,7 +578,7 @@ stmt_node_t Parser::class_declaration() {
     consume("Expected '}' at the end of class declaration", TokenType::RIGHT_BRACE);
     auto *class_definition =
         allocate_node(ClassStmt, std::move(name), ctor, dtor, std::move(members), std::move(methods));
-    current_module.classes.push_back(class_definition);
+    current_module.classes[class_definition->name.lexeme] = class_definition;
 
     return stmt_node_t{class_definition};
 }
@@ -588,10 +586,8 @@ stmt_node_t Parser::class_declaration() {
 stmt_node_t Parser::function_declaration() {
     consume("Expected function name after 'fn' keyword", TokenType::IDENTIFIER);
 
-    for (auto *func : current_module.functions) {
-        if (func->name.lexeme == previous().lexeme) {
-            throw_parse_error("Function already defined");
-        }
+    if (current_module.functions.find(previous().lexeme) != current_module.functions.end()) {
+        throw_parse_error("Function already defined");
     }
 
     Token name = previous();
@@ -630,7 +626,7 @@ stmt_node_t Parser::function_declaration() {
         allocate_node(FunctionStmt, std::move(name), std::move(return_type), std::move(params), std::move(body));
 
     if (!in_class && scope_depth == 1) {
-        current_module.functions.push_back(function_definition);
+        current_module.functions[function_definition->name.lexeme] = function_definition;
     }
 
     return stmt_node_t{function_definition};

--- a/src/Parser/TypeResolver.hpp
+++ b/src/Parser/TypeResolver.hpp
@@ -22,8 +22,8 @@ class TypeResolver final : Visitor {
     };
 
     Module &current_module;
-    const std::vector<ClassStmt *> &classes;
-    const std::vector<FunctionStmt *> &functions;
+    const std::unordered_map<std::string_view, ClassStmt *> &classes;
+    const std::unordered_map<std::string_view, FunctionStmt *> &functions;
     std::vector<type_node_t> type_scratch_space{};
     std::vector<Value> values{};
 
@@ -40,7 +40,8 @@ class TypeResolver final : Visitor {
     BaseType *make_new_type(Type type, bool is_const, bool is_ref, Args &&... args);
     ExprTypeInfo resolve_class_access(ExprVisitorType &object, const Token &name);
     ExprVisitorType check_inbuilt(VariableExpr *function, const Token &oper, std::vector<expr_node_t> &args);
-    ClassStmt *find_class(const UserDefinedType &class_name);
+    ClassStmt *find_class(const std::string &class_name);
+    FunctionStmt *find_function(const std::string &function_name);
 
   public:
     TypeResolver(Module &module);

--- a/src/Token.hpp
+++ b/src/Token.hpp
@@ -21,6 +21,8 @@ struct Token {
 
     Token(TokenType type, std::string lexeme, std::size_t line, std::size_t start, std::size_t end)
         : type{type}, lexeme{std::move(lexeme)}, line{line}, start{start}, end{end} {}
+
+    bool operator==(const Token &other) { return lexeme == other.lexeme; }
 };
 
 #endif


### PR DESCRIPTION
Increased the performance of `TypeResolver::find_class` by approx. 14x for the test case of examples/test.wis. Previously with the release build, it took 7 seconds to run. By switching the way classes are stored in modules from a `std::vector<ClassStmt*>` to a `std::unordered_map<std::string_view, ClassStmt*>`, it went down to 0.5s