### PR TITLE
Make all instructions 4 bytes long

### DIFF
--- a/src/CodeGen/CodeGen.cpp
+++ b/src/CodeGen/CodeGen.cpp
@@ -37,9 +37,7 @@ void Generator::patch_jump(std::size_t jump_idx, std::size_t jump_amount) {
         return;
     }
 
-    current_chunk->bytes[jump_idx + 1] = (jump_amount >> 16) & 0xff;
-    current_chunk->bytes[jump_idx + 2] = (jump_amount >> 8) & 0xff;
-    current_chunk->bytes[jump_idx + 3] = jump_amount & 0xff;
+    current_chunk->bytes[jump_idx] |= jump_amount & 0x00ff'ffff;
 }
 
 RuntimeModule Generator::compile(Module &module) {
@@ -73,9 +71,7 @@ void Generator::emit_conversion(NumericConversionType conversion_type, std::size
 }
 
 void Generator::emit_three_bytes_of(std::size_t value) {
-    current_chunk->emit_byte((value >> 16) & 0xff);
-    current_chunk->emit_byte((value >> 8) & 0xff);
-    current_chunk->emit_byte(value & 0xff);
+    current_chunk->bytes.back() |= value & 0x00ff'ffff;
 }
 
 ExprVisitorType Generator::compile(Expr *expr) {
@@ -521,12 +517,11 @@ ExprVisitorType Generator::visit(LogicalExpr &expr) {
     } else { // Since || / or short circuits on true, flip the boolean on top of the stack
         jump_idx = current_chunk->emit_instruction(Instruction::JUMP_IF_FALSE, expr.resolved.token.line);
     }
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
     current_chunk->emit_instruction(Instruction::POP, expr.resolved.token.line);
     compile(expr.right.get());
     std::size_t to_idx = current_chunk->bytes.size();
-    patch_jump(jump_idx, to_idx - jump_idx - 4);
+    patch_jump(jump_idx, to_idx - jump_idx - 1);
     return {};
 }
 
@@ -567,22 +562,20 @@ ExprVisitorType Generator::visit(TernaryExpr &expr) {
 
     std::size_t condition_jump_idx =
         current_chunk->emit_instruction(Instruction::POP_JUMP_IF_FALSE, expr.resolved.token.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
 
     compile(expr.middle.get());
 
     std::size_t over_false_idx = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, expr.resolved.token.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
     std::size_t false_to_idx = current_chunk->bytes.size();
 
     compile(expr.right.get());
 
     std::size_t true_to_idx = current_chunk->bytes.size();
 
-    patch_jump(condition_jump_idx, false_to_idx - condition_jump_idx - 4);
-    patch_jump(over_false_idx, true_to_idx - over_false_idx - 4);
+    patch_jump(condition_jump_idx, false_to_idx - condition_jump_idx - 1);
+    patch_jump(over_false_idx, true_to_idx - over_false_idx - 1);
     return {};
 }
 
@@ -674,8 +667,7 @@ StmtVisitorType Generator::visit(BlockStmt &stmt) {
 
 StmtVisitorType Generator::visit(BreakStmt &stmt) {
     std::size_t break_idx = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, stmt.keyword.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
     break_stmts.top().push_back(break_idx);
 }
 
@@ -683,8 +675,7 @@ StmtVisitorType Generator::visit(ClassStmt &stmt) {}
 
 StmtVisitorType Generator::visit(ContinueStmt &stmt) {
     std::size_t continue_idx = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, stmt.keyword.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
     continue_stmts.top().push_back(continue_idx);
 }
 
@@ -736,17 +727,18 @@ StmtVisitorType Generator::visit(IfStmt &stmt) {
         current_chunk->emit_instruction(Instruction::DEREF, stmt.condition->resolved.token.line);
     }
     std::size_t jump_idx = current_chunk->emit_instruction(Instruction::POP_JUMP_IF_FALSE, stmt.keyword.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
     // Reserve three bytes for the offset
     compile(stmt.thenBranch.get());
 
-    std::size_t over_else = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, stmt.keyword.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    std::size_t over_else = 0;
+    if (stmt.elseBranch != nullptr) {
+        over_else = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, stmt.keyword.line);
+        emit_three_bytes_of(0);
+    }
 
     std::size_t before_else = current_chunk->bytes.size();
-    patch_jump(jump_idx, before_else - jump_idx - 4);
+    patch_jump(jump_idx, before_else - jump_idx - 1);
     /*
      * The -4 because:
      *
@@ -765,10 +757,10 @@ StmtVisitorType Generator::visit(IfStmt &stmt) {
      */
     if (stmt.elseBranch != nullptr) {
         compile(stmt.elseBranch.get());
-    }
 
-    std::size_t after_else = current_chunk->bytes.size();
-    patch_jump(over_else, after_else - over_else - 4);
+        std::size_t after_else = current_chunk->bytes.size();
+        patch_jump(over_else, after_else - over_else - 1);
+    }
 }
 
 StmtVisitorType Generator::visit(ReturnStmt &stmt) {
@@ -825,31 +817,29 @@ StmtVisitorType Generator::visit(SwitchStmt &stmt) {
         compile(case_.first.get());
         jumps.push_back(
             current_chunk->emit_instruction(Instruction::POP_JUMP_IF_EQUAL, current_chunk->line_numbers.back().first));
-        current_chunk->emit_bytes(0, 0);
-        current_chunk->emit_byte(0);
+        emit_three_bytes_of(0);
     }
     if (stmt.default_case != nullptr) {
         default_jump = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, 0);
-        current_chunk->emit_bytes(0, 0);
-        current_chunk->emit_byte(0);
+        emit_three_bytes_of(0);
     }
 
     std::size_t i = 0;
     for (auto &case_ : stmt.cases) {
         std::size_t jump_to = current_chunk->bytes.size();
-        patch_jump(jumps[i], jump_to - jumps[i] - 4);
+        patch_jump(jumps[i], jump_to - jumps[i] - 1);
         compile(case_.second.get());
         i++;
     }
     if (stmt.default_case != nullptr) {
         std::size_t jump_to = current_chunk->bytes.size();
-        patch_jump(default_jump, jump_to - default_jump - 4);
+        patch_jump(default_jump, jump_to - default_jump - 1);
         compile(stmt.default_case.get());
     }
 
     for (std::size_t break_stmt : break_stmts.top()) {
         std::size_t jump_to = current_chunk->bytes.size();
-        patch_jump(break_stmt, jump_to - break_stmt - 4);
+        patch_jump(break_stmt, jump_to - break_stmt - 1);
     }
 
     break_stmts.pop();
@@ -961,8 +951,7 @@ StmtVisitorType Generator::visit(WhileStmt &stmt) {
     continue_stmts.emplace();
 
     std::size_t jump_begin_idx = current_chunk->emit_instruction(Instruction::JUMP_FORWARD, stmt.keyword.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
 
     std::size_t loop_back_idx = current_chunk->bytes.size();
     compile(stmt.body.get());
@@ -979,20 +968,19 @@ StmtVisitorType Generator::visit(WhileStmt &stmt) {
     }
 
     std::size_t jump_back_idx = current_chunk->emit_instruction(Instruction::POP_JUMP_BACK_IF_TRUE, stmt.keyword.line);
-    current_chunk->emit_bytes(0, 0);
-    current_chunk->emit_byte(0);
+    emit_three_bytes_of(0);
 
     std::size_t loop_end_idx = current_chunk->bytes.size();
 
-    patch_jump(jump_back_idx, jump_back_idx - loop_back_idx + 4);
-    patch_jump(jump_begin_idx, condition_idx - jump_begin_idx - 4);
+    patch_jump(jump_back_idx, jump_back_idx - loop_back_idx + 1);
+    patch_jump(jump_begin_idx, condition_idx - jump_begin_idx - 1);
 
     for (std::size_t continue_idx : continue_stmts.top()) {
-        patch_jump(continue_idx, increment_idx - continue_idx - 4);
+        patch_jump(continue_idx, increment_idx - continue_idx - 1);
     }
 
     for (std::size_t break_idx : break_stmts.top()) {
-        patch_jump(break_idx, loop_end_idx - break_idx - 3);
+        patch_jump(break_idx, loop_end_idx - break_idx - 1);
     }
 
     continue_stmts.pop();

--- a/src/VirtualMachine/Chunk.hpp
+++ b/src/VirtualMachine/Chunk.hpp
@@ -20,9 +20,9 @@ struct Chunk {
     static constexpr std::size_t const_short_max = (1 << 8) - 1;
     static constexpr std::size_t const_long_max = (std::size_t{1} << 24) - 1;
 
-    using byte = std::uint8_t;
+    using InstructionSizeType = std::uint32_t;
 
-    std::vector<byte> bytes{};
+    std::vector<InstructionSizeType> bytes{};
     std::vector<Value> constants{};
     std::deque<HashedString> strings{};
     std::vector<std::pair<std::size_t, std::size_t>> line_numbers{};
@@ -32,12 +32,11 @@ struct Chunk {
     explicit Chunk() = default;
     std::size_t add_constant(Value value);
     std::size_t add_string(std::string value);
-    std::size_t emit_byte(Chunk::byte value);
-    std::size_t emit_bytes(Chunk::byte value_1, Chunk::byte value_2);
+    std::size_t emit_byte(Chunk::InstructionSizeType value);
+    std::size_t emit_bytes(Chunk::InstructionSizeType value_1, Chunk::InstructionSizeType value_2);
     std::size_t emit_constant(Value value, std::size_t line_number);
     std::size_t emit_string(std::string value, std::size_t line_number);
     std::size_t emit_instruction(Instruction instruction, std::size_t line_number);
-    std::size_t emit_integer(std::size_t integer);
 
     std::size_t get_line_number(std::size_t insn_ptr);
 };

--- a/src/VirtualMachine/Disassembler.cpp
+++ b/src/VirtualMachine/Disassembler.cpp
@@ -84,6 +84,12 @@ void instruction(Chunk &chunk, std::string_view name, std::size_t where) {
     } else if (name == "MAKE_REF_TO_GLOBAL") {
         std::cout << "\t\t| make ref to global " << next_bytes << '\n';
         print_trailing_bytes();
+    } else if (name == "ACCESS_LOCAL" || name == "ACCESS_LOCAL_STRING") {
+        std::cout << "\t\t| access local " << next_bytes << '\n';
+        print_trailing_bytes();
+    } else if (name == "ACCESS_GLOBAL" || name == "ACCESS_GLOBAL_STRING") {
+        std::cout << "\t\t| access global " << next_bytes << '\n';
+        print_trailing_bytes();
     } else if (name == "RETURN") {
         std::cout << "\t\t| pop " << next_bytes << " local(s)\n";
         print_trailing_bytes();

--- a/src/VirtualMachine/Disassembler.cpp
+++ b/src/VirtualMachine/Disassembler.cpp
@@ -32,124 +32,132 @@ void disassemble(Chunk &chunk, std::string_view name) {
 
 std::ostream &print_preamble(Chunk &chunk, std::string_view name, std::size_t byte, std::size_t insn_ptr) {
     static std::size_t previous_line_number = -1;
-    if (std::size_t line_number = chunk.get_line_number(insn_ptr); line_number == previous_line_number) {
+    std::size_t line_number = chunk.get_line_number(insn_ptr);
+    if (line_number == previous_line_number) {
         std::cout << std::setw(4) << std::setfill(' ') << "|"
                   << "  ";
     } else {
         previous_line_number = line_number;
-        std::cout << std::setw(4) << std::setfill('0') << chunk.get_line_number(insn_ptr) << "  ";
+        std::cout << std::setw(4) << std::setfill('0') << line_number << "  ";
     }
-    std::cout << std::hex << std::setw(8) << std::setfill('0') << byte;
-    std::cout << std::resetiosflags(std::ios_base::hex);
+    std::cout << std::hex << std::setw(8) << std::setfill('0') << byte << std::resetiosflags(std::ios_base::hex);
     print_tab(1, 4) << std::setw(8) << byte;
     return print_tab(1, 4) << name;
 }
 
-std::size_t four_byte_insn(Chunk &chunk, std::string_view name, std::size_t byte) {
-    print_preamble(chunk, name, byte * 4, byte + 1) << '\t';
-    std::size_t next_bytes = chunk.bytes[byte] & 0x00ff'ffff;
+void instruction(Chunk &chunk, std::string_view name, std::size_t where) {
+    print_preamble(chunk, name, where * 4, where + 1);
+    std::size_t next_bytes = chunk.bytes[where] & 0x00ff'ffff;
+
+    auto print_trailing_bytes = [&chunk, &where] {
+        for (int i = 1; i < 4; i++) {
+            std::size_t offset_bit = chunk.bytes[where] & (0xff << (8 * (3 - i)));
+            print_preamble(chunk, "", where * 4 + i, where + 1) << "| " << std::hex << std::setw(8) << offset_bit;
+            print_tab(1, 2) << std::resetiosflags(std::ios_base::hex) << std::setw(8) << offset_bit << '\n';
+        }
+    };
+
+    // To avoid polluting the output with unnecessary zeroes, the instruction operand is only printed for specific
+    // instructions
     if (name == "CONSTANT" || name == "CONSTANT_STRING") {
-        std::cout << '\t';
+        std::cout << "\t\t";
         print_tab(1) << "-> " << next_bytes << " | value = " << chunk.constants[next_bytes].repr() << '\n';
+        print_trailing_bytes();
     } else if (name == "JUMP_FORWARD" || name == "POP_JUMP_IF_FALSE" || name == "JUMP_IF_FALSE" ||
                name == "JUMP_IF_TRUE" || name == "POP_JUMP_IF_EQUAL") {
-        std::cout << "\t| offset = +" << (next_bytes + 1) * 4 << " bytes, jump to = " << 4 * (byte + next_bytes + 1)
+        std::cout << "\t\t| offset = +" << (next_bytes + 1) * 4 << " bytes, jump to = " << 4 * (where + next_bytes + 1)
                   << '\n';
+        print_trailing_bytes();
     } else if (name == "JUMP_BACKWARD" || name == "POP_JUMP_BACK_IF_TRUE") {
-        std::cout << "\t| offset = -" << (next_bytes - 1) * 4 << " bytes, jump to = " << 4 * (byte + 1 - next_bytes)
+        std::cout << "\t\t| offset = -" << (next_bytes - 1) * 4 << " bytes, jump to = " << 4 * (where + 1 - next_bytes)
                   << '\n';
+        print_trailing_bytes();
     } else if (name == "ASSIGN_LOCAL") {
-        std::cout << "\t| assign to local " << next_bytes << '\n';
+        std::cout << "\t\t| assign to local " << next_bytes << '\n';
+        print_trailing_bytes();
     } else if (name == "ASSIGN_GLOBAL") {
-        std::cout << "\t| assign to global " << next_bytes << '\n';
+        std::cout << "\t\t| assign to global " << next_bytes << '\n';
+        print_trailing_bytes();
     } else if (name == "MAKE_REF_TO_LOCAL") {
-        std::cout << "\t| make ref to local " << next_bytes << '\n';
+        std::cout << "\t\t| make ref to local " << next_bytes << '\n';
+        print_trailing_bytes();
     } else if (name == "MAKE_REF_TO_GLOBAL") {
-        std::cout << "\t| make ref to global " << next_bytes << '\n';
-    } else if (name == "INCR_LOCAL" || name == "DECR_LOCAL" || name == "MUL_LOCAL" || name == "DIV_LOCAL" ||
-               name == "INCR_GLOBAL" || name == "DECR_GLOBAL" || name == "MUL_GLOBAL" || name == "DIV_GLOBAL") {
-        print_tab(1) << "| modify " << next_bytes << '\n';
+        std::cout << "\t\t| make ref to global " << next_bytes << '\n';
+        print_trailing_bytes();
     } else if (name == "RETURN") {
-        std::cout << "\t| pop " << next_bytes << " local(s)\n";
+        std::cout << "\t\t| pop " << next_bytes << " local(s)\n";
+        print_trailing_bytes();
     } else {
         std::cout << '\n';
     }
-
-    for (int i = 1; i < 4; i++) {
-        std::size_t offset_bit = chunk.bytes[byte] & (0xff << (8 * (3 - i)));
-        print_preamble(chunk, "", byte * 4 + i, byte + 1) << "| " << std::hex << std::setw(8) << offset_bit;
-        print_tab(1, 2) << std::resetiosflags(std::ios_base::hex) << std::setw(8) << offset_bit << '\n';
-    }
-
-    return 4;
 }
 
-std::size_t disassemble_instruction(Chunk &chunk, Instruction instruction, std::size_t byte) {
-    switch (instruction) {
-        case Instruction::HALT: return four_byte_insn(chunk, "HALT", byte);
-        case Instruction::POP: return four_byte_insn(chunk, "POP", byte);
-        case Instruction::CONSTANT: return four_byte_insn(chunk, "CONSTANT", byte);
-        case Instruction::IADD: return four_byte_insn(chunk, "IADD", byte);
-        case Instruction::ISUB: return four_byte_insn(chunk, "ISUB", byte);
-        case Instruction::IMUL: return four_byte_insn(chunk, "IMUL", byte);
-        case Instruction::IDIV: return four_byte_insn(chunk, "IDIV", byte);
-        case Instruction::IMOD: return four_byte_insn(chunk, "IMOD", byte);
-        case Instruction::INEG: return four_byte_insn(chunk, "INEG", byte);
-        case Instruction::FADD: return four_byte_insn(chunk, "FADD", byte);
-        case Instruction::FSUB: return four_byte_insn(chunk, "FSUB", byte);
-        case Instruction::FMUL: return four_byte_insn(chunk, "FMUL", byte);
-        case Instruction::FDIV: return four_byte_insn(chunk, "FDIV", byte);
-        case Instruction::FMOD: return four_byte_insn(chunk, "FMOD", byte);
-        case Instruction::FNEG: return four_byte_insn(chunk, "FNEG", byte);
-        case Instruction::FLOAT_TO_INT: return four_byte_insn(chunk, "FLOAT_TO_INT", byte);
-        case Instruction::INT_TO_FLOAT: return four_byte_insn(chunk, "INT_TO_FLOAT", byte);
-        case Instruction::SHIFT_LEFT: return four_byte_insn(chunk, "SHIFT_LEFT", byte);
-        case Instruction::SHIFT_RIGHT: return four_byte_insn(chunk, "SHIFT_RIGHT", byte);
-        case Instruction::BIT_AND: return four_byte_insn(chunk, "BIT_AND", byte);
-        case Instruction::BIT_OR: return four_byte_insn(chunk, "BIT_OR", byte);
-        case Instruction::BIT_NOT: return four_byte_insn(chunk, "BIT_NOT", byte);
-        case Instruction::BIT_XOR: return four_byte_insn(chunk, "BIT_XOR", byte);
-        case Instruction::NOT: return four_byte_insn(chunk, "NOT", byte);
-        case Instruction::EQUAL: return four_byte_insn(chunk, "EQUAL", byte);
-        case Instruction::GREATER: return four_byte_insn(chunk, "GREATER", byte);
-        case Instruction::LESSER: return four_byte_insn(chunk, "LESSER", byte);
-        case Instruction::PUSH_TRUE: return four_byte_insn(chunk, "PUSH_TRUE", byte);
-        case Instruction::PUSH_FALSE: return four_byte_insn(chunk, "PUSH_FALSE", byte);
-        case Instruction::PUSH_NULL: return four_byte_insn(chunk, "PUSH_NULL", byte);
-        case Instruction::JUMP_FORWARD: return four_byte_insn(chunk, "JUMP_FORWARD", byte);
-        case Instruction::JUMP_BACKWARD: return four_byte_insn(chunk, "JUMP_BACKWARD", byte);
-        case Instruction::JUMP_IF_TRUE: return four_byte_insn(chunk, "JUMP_IF_TRUE", byte);
-        case Instruction::JUMP_IF_FALSE: return four_byte_insn(chunk, "JUMP_IF_FALSE", byte);
-        case Instruction::POP_JUMP_IF_EQUAL: return four_byte_insn(chunk, "POP_JUMP_IF_EQUAL", byte);
-        case Instruction::POP_JUMP_IF_FALSE: return four_byte_insn(chunk, "POP_JUMP_IF_FALSE", byte);
-        case Instruction::POP_JUMP_BACK_IF_TRUE: return four_byte_insn(chunk, "POP_JUMP_BACK_IF_TRUE", byte);
-        case Instruction::ASSIGN_LOCAL: return four_byte_insn(chunk, "ASSIGN_LOCAL", byte);
-        case Instruction::ACCESS_LOCAL: return four_byte_insn(chunk, "ACCESS_LOCAL", byte);
-        case Instruction::MAKE_REF_TO_LOCAL: return four_byte_insn(chunk, "MAKE_REF_TO_LOCAL", byte);
-        case Instruction::DEREF: return four_byte_insn(chunk, "DEREF", byte);
-        case Instruction::ASSIGN_GLOBAL: return four_byte_insn(chunk, "ASSIGN_GLOBAL", byte);
-        case Instruction::ACCESS_GLOBAL: return four_byte_insn(chunk, "ACCESS_GLOBAL", byte);
-        case Instruction::MAKE_REF_TO_GLOBAL: return four_byte_insn(chunk, "MAKE_REF_TO_GLOBAL", byte);
-        case Instruction::LOAD_FUNCTION: return four_byte_insn(chunk, "LOAD_FUNCTION", byte);
-        case Instruction::CALL_FUNCTION: return four_byte_insn(chunk, "CALL_FUNCTION", byte);
-        case Instruction::CALL_NATIVE: return four_byte_insn(chunk, "CALL_NATIVE", byte);
-        case Instruction::RETURN: return four_byte_insn(chunk, "RETURN", byte);
-        case Instruction::TRAP_RETURN: return four_byte_insn(chunk, "TRAP_RETURN", byte);
-        case Instruction::CONSTANT_STRING: return four_byte_insn(chunk, "CONSTANT_STRING", byte);
-        case Instruction::ACCESS_LOCAL_STRING: return four_byte_insn(chunk, "ACCESS_LOCAL_STRING", byte);
-        case Instruction::ACCESS_GLOBAL_STRING: return four_byte_insn(chunk, "ACCESS_GLOBAL_STRING", byte);
-        case Instruction::POP_STRING: return four_byte_insn(chunk, "POP_STRING", byte);
-        case Instruction::CONCATENATE: return four_byte_insn(chunk, "CONCATENATE", byte);
-        case Instruction::MAKE_LIST: return four_byte_insn(chunk, "MAKE_LIST", byte);
-        case Instruction::COPY_LIST: return four_byte_insn(chunk, "COPY_LIST", byte);
-        case Instruction::APPEND_LIST: return four_byte_insn(chunk, "APPEND_LIST", byte);
-        case Instruction::ASSIGN_LIST: return four_byte_insn(chunk, "ASSIGN_LIST", byte);
-        case Instruction::INDEX_LIST: return four_byte_insn(chunk, "INDEX_LIST", byte);
-        case Instruction::CHECK_INDEX: return four_byte_insn(chunk, "CHECK_INDEX", byte);
-        case Instruction::ASSIGN_LOCAL_LIST: return four_byte_insn(chunk, "ASSIGN_LOCAL_LIST", byte);
-        case Instruction::ASSIGN_GLOBAL_LIST: return four_byte_insn(chunk, "ASSIGN_GLOBAL_LIST", byte);
-        case Instruction::POP_LIST: return four_byte_insn(chunk, "POP_LIST", byte);
-        case Instruction::ACCESS_FROM_TOP: return four_byte_insn(chunk, "ACCESS_FROM_TOP", byte);
+void disassemble_instruction(Chunk &chunk, Instruction insn, std::size_t where) {
+    switch (insn) {
+        case Instruction::HALT: instruction(chunk, "HALT", where); return;
+        case Instruction::POP: instruction(chunk, "POP", where); return;
+        case Instruction::CONSTANT: instruction(chunk, "CONSTANT", where); return;
+        case Instruction::IADD: instruction(chunk, "IADD", where); return;
+        case Instruction::ISUB: instruction(chunk, "ISUB", where); return;
+        case Instruction::IMUL: instruction(chunk, "IMUL", where); return;
+        case Instruction::IDIV: instruction(chunk, "IDIV", where); return;
+        case Instruction::IMOD: instruction(chunk, "IMOD", where); return;
+        case Instruction::INEG: instruction(chunk, "INEG", where); return;
+        case Instruction::FADD: instruction(chunk, "FADD", where); return;
+        case Instruction::FSUB: instruction(chunk, "FSUB", where); return;
+        case Instruction::FMUL: instruction(chunk, "FMUL", where); return;
+        case Instruction::FDIV: instruction(chunk, "FDIV", where); return;
+        case Instruction::FMOD: instruction(chunk, "FMOD", where); return;
+        case Instruction::FNEG: instruction(chunk, "FNEG", where); return;
+        case Instruction::FLOAT_TO_INT: instruction(chunk, "FLOAT_TO_INT", where); return;
+        case Instruction::INT_TO_FLOAT: instruction(chunk, "INT_TO_FLOAT", where); return;
+        case Instruction::SHIFT_LEFT: instruction(chunk, "SHIFT_LEFT", where); return;
+        case Instruction::SHIFT_RIGHT: instruction(chunk, "SHIFT_RIGHT", where); return;
+        case Instruction::BIT_AND: instruction(chunk, "BIT_AND", where); return;
+        case Instruction::BIT_OR: instruction(chunk, "BIT_OR", where); return;
+        case Instruction::BIT_NOT: instruction(chunk, "BIT_NOT", where); return;
+        case Instruction::BIT_XOR: instruction(chunk, "BIT_XOR", where); return;
+        case Instruction::NOT: instruction(chunk, "NOT", where); return;
+        case Instruction::EQUAL: instruction(chunk, "EQUAL", where); return;
+        case Instruction::GREATER: instruction(chunk, "GREATER", where); return;
+        case Instruction::LESSER: instruction(chunk, "LESSER", where); return;
+        case Instruction::PUSH_TRUE: instruction(chunk, "PUSH_TRUE", where); return;
+        case Instruction::PUSH_FALSE: instruction(chunk, "PUSH_FALSE", where); return;
+        case Instruction::PUSH_NULL: instruction(chunk, "PUSH_NULL", where); return;
+        case Instruction::JUMP_FORWARD: instruction(chunk, "JUMP_FORWARD", where); return;
+        case Instruction::JUMP_BACKWARD: instruction(chunk, "JUMP_BACKWARD", where); return;
+        case Instruction::JUMP_IF_TRUE: instruction(chunk, "JUMP_IF_TRUE", where); return;
+        case Instruction::JUMP_IF_FALSE: instruction(chunk, "JUMP_IF_FALSE", where); return;
+        case Instruction::POP_JUMP_IF_EQUAL: instruction(chunk, "POP_JUMP_IF_EQUAL", where); return;
+        case Instruction::POP_JUMP_IF_FALSE: instruction(chunk, "POP_JUMP_IF_FALSE", where); return;
+        case Instruction::POP_JUMP_BACK_IF_TRUE: instruction(chunk, "POP_JUMP_BACK_IF_TRUE", where); return;
+        case Instruction::ASSIGN_LOCAL: instruction(chunk, "ASSIGN_LOCAL", where); return;
+        case Instruction::ACCESS_LOCAL: instruction(chunk, "ACCESS_LOCAL", where); return;
+        case Instruction::MAKE_REF_TO_LOCAL: instruction(chunk, "MAKE_REF_TO_LOCAL", where); return;
+        case Instruction::DEREF: instruction(chunk, "DEREF", where); return;
+        case Instruction::ASSIGN_GLOBAL: instruction(chunk, "ASSIGN_GLOBAL", where); return;
+        case Instruction::ACCESS_GLOBAL: instruction(chunk, "ACCESS_GLOBAL", where); return;
+        case Instruction::MAKE_REF_TO_GLOBAL: instruction(chunk, "MAKE_REF_TO_GLOBAL", where); return;
+        case Instruction::LOAD_FUNCTION: instruction(chunk, "LOAD_FUNCTION", where); return;
+        case Instruction::CALL_FUNCTION: instruction(chunk, "CALL_FUNCTION", where); return;
+        case Instruction::CALL_NATIVE: instruction(chunk, "CALL_NATIVE", where); return;
+        case Instruction::RETURN: instruction(chunk, "RETURN", where); return;
+        case Instruction::TRAP_RETURN: instruction(chunk, "TRAP_RETURN", where); return;
+        case Instruction::CONSTANT_STRING: instruction(chunk, "CONSTANT_STRING", where); return;
+        case Instruction::ACCESS_LOCAL_STRING: instruction(chunk, "ACCESS_LOCAL_STRING", where); return;
+        case Instruction::ACCESS_GLOBAL_STRING: instruction(chunk, "ACCESS_GLOBAL_STRING", where); return;
+        case Instruction::POP_STRING: instruction(chunk, "POP_STRING", where); return;
+        case Instruction::CONCATENATE: instruction(chunk, "CONCATENATE", where); return;
+        case Instruction::MAKE_LIST: instruction(chunk, "MAKE_LIST", where); return;
+        case Instruction::COPY_LIST: instruction(chunk, "COPY_LIST", where); return;
+        case Instruction::APPEND_LIST: instruction(chunk, "APPEND_LIST", where); return;
+        case Instruction::ASSIGN_LIST: instruction(chunk, "ASSIGN_LIST", where); return;
+        case Instruction::INDEX_LIST: instruction(chunk, "INDEX_LIST", where); return;
+        case Instruction::CHECK_INDEX: instruction(chunk, "CHECK_INDEX", where); return;
+        case Instruction::ASSIGN_LOCAL_LIST: instruction(chunk, "ASSIGN_LOCAL_LIST", where); return;
+        case Instruction::ASSIGN_GLOBAL_LIST: instruction(chunk, "ASSIGN_GLOBAL_LIST", where); return;
+        case Instruction::POP_LIST: instruction(chunk, "POP_LIST", where); return;
+        case Instruction::ACCESS_FROM_TOP: instruction(chunk, "ACCESS_FROM_TOP", where); return;
     }
     unreachable();
 }

--- a/src/VirtualMachine/Disassembler.cpp
+++ b/src/VirtualMachine/Disassembler.cpp
@@ -25,7 +25,8 @@ void disassemble(Chunk &chunk, std::string_view name) {
     print_tab(1, 4) << "----------- ------------------------------------------------------\n";
     std::size_t i = 0;
     while (i < chunk.bytes.size()) {
-        i += disassemble_instruction(chunk, static_cast<Instruction>(chunk.bytes[i]), i);
+        disassemble_instruction(chunk, static_cast<Instruction>(chunk.bytes[i] >> 24), i);
+        i++;
     }
 }
 
@@ -44,41 +45,19 @@ std::ostream &print_preamble(Chunk &chunk, std::string_view name, std::size_t by
     return print_tab(1, 4) << name;
 }
 
-std::size_t single_byte_insn(Chunk &chunk, std::string_view name, std::size_t byte) {
-    print_preamble(chunk, name, byte, byte + 1) << '\n';
-    return 1;
-}
-
-std::size_t two_byte_insn(Chunk &chunk, std::string_view name, std::size_t byte) {
-    print_preamble(chunk, name, byte, byte + 1);
-    std::size_t next_byte = chunk.bytes[byte + 1];
-    if (name == "MAKE_LIST_OF") {
-        std::cout << '\t';
-        print_tab(1) << "| count: " << next_byte << '\n';
-    } else {
-        std::cout << "\t-> " << next_byte << '\n';
-    }
-
-    std::size_t offset_bit = chunk.bytes[byte + 1];
-    print_preamble(chunk, "", byte + 1, byte + 1) << "| " << std::hex << std::setw(8) << offset_bit;
-    print_tab(1, 2) << std::resetiosflags(std::ios_base::hex) << std::setw(8) << offset_bit << '\n';
-
-    return 2;
-}
-
 std::size_t four_byte_insn(Chunk &chunk, std::string_view name, std::size_t byte) {
-    print_preamble(chunk, name, byte, byte + 1) << '\t';
-    std::size_t next_bytes = chunk.bytes[byte + 1];
-    next_bytes = (next_bytes << 8) | chunk.bytes[byte + 2];
-    next_bytes = (next_bytes << 8) | chunk.bytes[byte + 3];
+    print_preamble(chunk, name, byte * 4, byte + 1) << '\t';
+    std::size_t next_bytes = chunk.bytes[byte] & 0x00ff'ffff;
     if (name == "CONSTANT" || name == "CONSTANT_STRING") {
         std::cout << '\t';
         print_tab(1) << "-> " << next_bytes << " | value = " << chunk.constants[next_bytes].repr() << '\n';
     } else if (name == "JUMP_FORWARD" || name == "POP_JUMP_IF_FALSE" || name == "JUMP_IF_FALSE" ||
                name == "JUMP_IF_TRUE" || name == "POP_JUMP_IF_EQUAL") {
-        std::cout << "\t| offset = +" << next_bytes << ", jump to = " << byte + next_bytes + 4 << '\n';
+        std::cout << "\t| offset = +" << (next_bytes + 1) * 4 << " bytes, jump to = " << 4 * (byte + next_bytes + 1)
+                  << '\n';
     } else if (name == "JUMP_BACKWARD" || name == "POP_JUMP_BACK_IF_TRUE") {
-        std::cout << "\t| offset = -" << next_bytes << ", jump to = " << byte + 4 - next_bytes << '\n';
+        std::cout << "\t| offset = -" << (next_bytes - 1) * 4 << " bytes, jump to = " << 4 * (byte + 1 - next_bytes)
+                  << '\n';
     } else if (name == "ASSIGN_LOCAL") {
         std::cout << "\t| assign to local " << next_bytes << '\n';
     } else if (name == "ASSIGN_GLOBAL") {
@@ -97,8 +76,8 @@ std::size_t four_byte_insn(Chunk &chunk, std::string_view name, std::size_t byte
     }
 
     for (int i = 1; i < 4; i++) {
-        std::size_t offset_bit = chunk.bytes[byte + i];
-        print_preamble(chunk, "", byte + i, byte + 1) << "| " << std::hex << std::setw(8) << offset_bit;
+        std::size_t offset_bit = chunk.bytes[byte] & (0xff << (8 * (3 - i)));
+        print_preamble(chunk, "", byte * 4 + i, byte + 1) << "| " << std::hex << std::setw(8) << offset_bit;
         print_tab(1, 2) << std::resetiosflags(std::ios_base::hex) << std::setw(8) << offset_bit << '\n';
     }
 
@@ -107,36 +86,36 @@ std::size_t four_byte_insn(Chunk &chunk, std::string_view name, std::size_t byte
 
 std::size_t disassemble_instruction(Chunk &chunk, Instruction instruction, std::size_t byte) {
     switch (instruction) {
-        case Instruction::HALT: return single_byte_insn(chunk, "HALT", byte);
-        case Instruction::POP: return single_byte_insn(chunk, "POP", byte);
+        case Instruction::HALT: return four_byte_insn(chunk, "HALT", byte);
+        case Instruction::POP: return four_byte_insn(chunk, "POP", byte);
         case Instruction::CONSTANT: return four_byte_insn(chunk, "CONSTANT", byte);
-        case Instruction::IADD: return single_byte_insn(chunk, "IADD", byte);
-        case Instruction::ISUB: return single_byte_insn(chunk, "ISUB", byte);
-        case Instruction::IMUL: return single_byte_insn(chunk, "IMUL", byte);
-        case Instruction::IDIV: return single_byte_insn(chunk, "IDIV", byte);
-        case Instruction::IMOD: return single_byte_insn(chunk, "IMOD", byte);
-        case Instruction::INEG: return single_byte_insn(chunk, "INEG", byte);
-        case Instruction::FADD: return single_byte_insn(chunk, "FADD", byte);
-        case Instruction::FSUB: return single_byte_insn(chunk, "FSUB", byte);
-        case Instruction::FMUL: return single_byte_insn(chunk, "FMUL", byte);
-        case Instruction::FDIV: return single_byte_insn(chunk, "FDIV", byte);
-        case Instruction::FMOD: return single_byte_insn(chunk, "FMOD", byte);
-        case Instruction::FNEG: return single_byte_insn(chunk, "FNEG", byte);
-        case Instruction::FLOAT_TO_INT: return single_byte_insn(chunk, "FLOAT_TO_INT", byte);
-        case Instruction::INT_TO_FLOAT: return single_byte_insn(chunk, "INT_TO_FLOAT", byte);
-        case Instruction::SHIFT_LEFT: return single_byte_insn(chunk, "SHIFT_LEFT", byte);
-        case Instruction::SHIFT_RIGHT: return single_byte_insn(chunk, "SHIFT_RIGHT", byte);
-        case Instruction::BIT_AND: return single_byte_insn(chunk, "BIT_AND", byte);
-        case Instruction::BIT_OR: return single_byte_insn(chunk, "BIT_OR", byte);
-        case Instruction::BIT_NOT: return single_byte_insn(chunk, "BIT_NOT", byte);
-        case Instruction::BIT_XOR: return single_byte_insn(chunk, "BIT_XOR", byte);
-        case Instruction::NOT: return single_byte_insn(chunk, "NOT", byte);
-        case Instruction::EQUAL: return single_byte_insn(chunk, "EQUAL", byte);
-        case Instruction::GREATER: return single_byte_insn(chunk, "GREATER", byte);
-        case Instruction::LESSER: return single_byte_insn(chunk, "LESSER", byte);
-        case Instruction::PUSH_TRUE: return single_byte_insn(chunk, "PUSH_TRUE", byte);
-        case Instruction::PUSH_FALSE: return single_byte_insn(chunk, "PUSH_FALSE", byte);
-        case Instruction::PUSH_NULL: return single_byte_insn(chunk, "PUSH_NULL", byte);
+        case Instruction::IADD: return four_byte_insn(chunk, "IADD", byte);
+        case Instruction::ISUB: return four_byte_insn(chunk, "ISUB", byte);
+        case Instruction::IMUL: return four_byte_insn(chunk, "IMUL", byte);
+        case Instruction::IDIV: return four_byte_insn(chunk, "IDIV", byte);
+        case Instruction::IMOD: return four_byte_insn(chunk, "IMOD", byte);
+        case Instruction::INEG: return four_byte_insn(chunk, "INEG", byte);
+        case Instruction::FADD: return four_byte_insn(chunk, "FADD", byte);
+        case Instruction::FSUB: return four_byte_insn(chunk, "FSUB", byte);
+        case Instruction::FMUL: return four_byte_insn(chunk, "FMUL", byte);
+        case Instruction::FDIV: return four_byte_insn(chunk, "FDIV", byte);
+        case Instruction::FMOD: return four_byte_insn(chunk, "FMOD", byte);
+        case Instruction::FNEG: return four_byte_insn(chunk, "FNEG", byte);
+        case Instruction::FLOAT_TO_INT: return four_byte_insn(chunk, "FLOAT_TO_INT", byte);
+        case Instruction::INT_TO_FLOAT: return four_byte_insn(chunk, "INT_TO_FLOAT", byte);
+        case Instruction::SHIFT_LEFT: return four_byte_insn(chunk, "SHIFT_LEFT", byte);
+        case Instruction::SHIFT_RIGHT: return four_byte_insn(chunk, "SHIFT_RIGHT", byte);
+        case Instruction::BIT_AND: return four_byte_insn(chunk, "BIT_AND", byte);
+        case Instruction::BIT_OR: return four_byte_insn(chunk, "BIT_OR", byte);
+        case Instruction::BIT_NOT: return four_byte_insn(chunk, "BIT_NOT", byte);
+        case Instruction::BIT_XOR: return four_byte_insn(chunk, "BIT_XOR", byte);
+        case Instruction::NOT: return four_byte_insn(chunk, "NOT", byte);
+        case Instruction::EQUAL: return four_byte_insn(chunk, "EQUAL", byte);
+        case Instruction::GREATER: return four_byte_insn(chunk, "GREATER", byte);
+        case Instruction::LESSER: return four_byte_insn(chunk, "LESSER", byte);
+        case Instruction::PUSH_TRUE: return four_byte_insn(chunk, "PUSH_TRUE", byte);
+        case Instruction::PUSH_FALSE: return four_byte_insn(chunk, "PUSH_FALSE", byte);
+        case Instruction::PUSH_NULL: return four_byte_insn(chunk, "PUSH_NULL", byte);
         case Instruction::JUMP_FORWARD: return four_byte_insn(chunk, "JUMP_FORWARD", byte);
         case Instruction::JUMP_BACKWARD: return four_byte_insn(chunk, "JUMP_BACKWARD", byte);
         case Instruction::JUMP_IF_TRUE: return four_byte_insn(chunk, "JUMP_IF_TRUE", byte);
@@ -147,29 +126,29 @@ std::size_t disassemble_instruction(Chunk &chunk, Instruction instruction, std::
         case Instruction::ASSIGN_LOCAL: return four_byte_insn(chunk, "ASSIGN_LOCAL", byte);
         case Instruction::ACCESS_LOCAL: return four_byte_insn(chunk, "ACCESS_LOCAL", byte);
         case Instruction::MAKE_REF_TO_LOCAL: return four_byte_insn(chunk, "MAKE_REF_TO_LOCAL", byte);
-        case Instruction::DEREF: return single_byte_insn(chunk, "DEREF", byte);
+        case Instruction::DEREF: return four_byte_insn(chunk, "DEREF", byte);
         case Instruction::ASSIGN_GLOBAL: return four_byte_insn(chunk, "ASSIGN_GLOBAL", byte);
         case Instruction::ACCESS_GLOBAL: return four_byte_insn(chunk, "ACCESS_GLOBAL", byte);
         case Instruction::MAKE_REF_TO_GLOBAL: return four_byte_insn(chunk, "MAKE_REF_TO_GLOBAL", byte);
-        case Instruction::LOAD_FUNCTION: return single_byte_insn(chunk, "LOAD_FUNCTION", byte);
-        case Instruction::CALL_FUNCTION: return single_byte_insn(chunk, "CALL_FUNCTION", byte);
-        case Instruction::CALL_NATIVE: return single_byte_insn(chunk, "CALL_NATIVE", byte);
+        case Instruction::LOAD_FUNCTION: return four_byte_insn(chunk, "LOAD_FUNCTION", byte);
+        case Instruction::CALL_FUNCTION: return four_byte_insn(chunk, "CALL_FUNCTION", byte);
+        case Instruction::CALL_NATIVE: return four_byte_insn(chunk, "CALL_NATIVE", byte);
         case Instruction::RETURN: return four_byte_insn(chunk, "RETURN", byte);
-        case Instruction::TRAP_RETURN: return single_byte_insn(chunk, "TRAP_RETURN", byte);
+        case Instruction::TRAP_RETURN: return four_byte_insn(chunk, "TRAP_RETURN", byte);
         case Instruction::CONSTANT_STRING: return four_byte_insn(chunk, "CONSTANT_STRING", byte);
         case Instruction::ACCESS_LOCAL_STRING: return four_byte_insn(chunk, "ACCESS_LOCAL_STRING", byte);
         case Instruction::ACCESS_GLOBAL_STRING: return four_byte_insn(chunk, "ACCESS_GLOBAL_STRING", byte);
-        case Instruction::POP_STRING: return single_byte_insn(chunk, "POP_STRING", byte);
-        case Instruction::CONCATENATE: return single_byte_insn(chunk, "CONCATENATE", byte);
-        case Instruction::MAKE_LIST: return single_byte_insn(chunk, "MAKE_LIST", byte);
-        case Instruction::COPY_LIST: return single_byte_insn(chunk, "COPY_LIST", byte);
-        case Instruction::APPEND_LIST: return single_byte_insn(chunk, "APPEND_LIST", byte);
-        case Instruction::ASSIGN_LIST: return single_byte_insn(chunk, "ASSIGN_LIST", byte);
-        case Instruction::INDEX_LIST: return single_byte_insn(chunk, "INDEX_LIST", byte);
-        case Instruction::CHECK_INDEX: return single_byte_insn(chunk, "CHECK_INDEX", byte);
+        case Instruction::POP_STRING: return four_byte_insn(chunk, "POP_STRING", byte);
+        case Instruction::CONCATENATE: return four_byte_insn(chunk, "CONCATENATE", byte);
+        case Instruction::MAKE_LIST: return four_byte_insn(chunk, "MAKE_LIST", byte);
+        case Instruction::COPY_LIST: return four_byte_insn(chunk, "COPY_LIST", byte);
+        case Instruction::APPEND_LIST: return four_byte_insn(chunk, "APPEND_LIST", byte);
+        case Instruction::ASSIGN_LIST: return four_byte_insn(chunk, "ASSIGN_LIST", byte);
+        case Instruction::INDEX_LIST: return four_byte_insn(chunk, "INDEX_LIST", byte);
+        case Instruction::CHECK_INDEX: return four_byte_insn(chunk, "CHECK_INDEX", byte);
         case Instruction::ASSIGN_LOCAL_LIST: return four_byte_insn(chunk, "ASSIGN_LOCAL_LIST", byte);
         case Instruction::ASSIGN_GLOBAL_LIST: return four_byte_insn(chunk, "ASSIGN_GLOBAL_LIST", byte);
-        case Instruction::POP_LIST: return single_byte_insn(chunk, "POP_LIST", byte);
+        case Instruction::POP_LIST: return four_byte_insn(chunk, "POP_LIST", byte);
         case Instruction::ACCESS_FROM_TOP: return four_byte_insn(chunk, "ACCESS_FROM_TOP", byte);
     }
     unreachable();

--- a/src/VirtualMachine/Disassembler.hpp
+++ b/src/VirtualMachine/Disassembler.hpp
@@ -12,6 +12,6 @@
 #include <string_view>
 
 void disassemble(Chunk &chunk, std::string_view name);
-std::size_t disassemble_instruction(Chunk &chunk, Instruction instruction, std::size_t byte);
+void disassemble_instruction(Chunk &chunk, Instruction instruction, std::size_t where);
 
 #endif

--- a/src/VirtualMachine/VirtualMachine.hpp
+++ b/src/VirtualMachine/VirtualMachine.hpp
@@ -16,7 +16,7 @@
 struct CallFrame {
     Value *stack{};
     Chunk *return_chunk{};
-    Chunk::byte *return_ip{};
+    Chunk::InstructionSizeType *return_ip{};
 };
 
 enum class ExecutionState { RUNNING = 0, FINISHED = 1 };
@@ -25,7 +25,7 @@ class VirtualMachine {
     constexpr static std::size_t stack_size = 32768;
     constexpr static std::size_t frame_size = 1024;
 
-    Chunk::byte *ip{};
+    Chunk::InstructionSizeType *ip{};
 
     std::unique_ptr<Value[]> stack{};
     std::size_t stack_top{};
@@ -39,7 +39,7 @@ class VirtualMachine {
     Chunk *current_chunk{};
     RuntimeModule *current_module{};
 
-    Chunk::byte read_byte();
+    Chunk::InstructionSizeType read_next();
     std::size_t read_three_bytes();
 
     bool trace_stack{false};


### PR DESCRIPTION
Previously, the VM had either 1 byte instructions (those with no operands), or 4 byte instructions (1 byte of instruction followed by 3 bytes of an operand).  With these commits, the VM now supports all instructions being 4 bytes long, which leads to an increase in speed as:

1. The operand is read along with the instruction in one read instead of two (one for the instruction and one for the operand after decoding the instruction).
2. All instruction stream reads are aligned now on a 4-byte boundary.