### PR TITLE
chore: use official pre-commit mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/ssciwr/clang-format-hook
+  - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.0
     hooks:
       - id: clang-format


### PR DESCRIPTION
The original repository is being deprecated in favor of the automatically maintained pre-commit mirror.